### PR TITLE
Fix help for subcommands

### DIFF
--- a/activate
+++ b/activate
@@ -20,6 +20,8 @@ function uenv {
         echo "@@version@@";
     elif [[ $# -eq 0 || "$1" = "--help" || "$1" = "-h" ]]; then
         usage;
+    elif [[ " $* " =~ [[:space:]](-h|--help)[[:space:]] ]]; then
+        echo "$($UENV_CMD "$@")"
     else
         eval "$($UENV_CMD "$@")"
     fi


### PR DESCRIPTION
Help messages for subcommands are inaccessible.

```console
$ uenv modules -h
-bash: usage:: command not found
-bash: positional: command not found
-bash: {use}: command not found
-bash: use: command not found
-bash: optional: command not found
-bash: -h,: command not found
```

This happens because `uenv-impl` can either:
- print an actual (list of) bash command(s)
- print some output (e.g. help about how to use a sub-command).

With this PR, whenever `--help` (or `-h`) appears as argument, it will not `eval` the output of the command but it will just output it on the terminal.

```console
$ uenv modules -h
usage: uenv-impl modules [-h] {use} ...

positional arguments:
  {use}
    use       use modules if they are available

optional arguments:
  -h, --help  show this help message and exit
```