### PR TITLE
Fix CI

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -15,7 +15,7 @@ function setup() {
     echo "=== make a back up of ~/.bashrc -> $base_path/bashrc"
     cp ~/.bashrc "$base_path/bashrc"
 
-    "$repo_path/install" --prefix="$repo_path" --yes
+    "$repo_path/install" --prefix="$repo_path" --local --yes
 
     [[ -d "$base_path/bin" ]] && export PATH="$base_path/bin:$PATH"
     echo "BIN: $(ls $base_path/bin)"


### PR DESCRIPTION
No access to system directories is available inside GH actions.
```
# installing /etc/profile.d/uenv.sh
# cp: cannot create regular file '/etc/profile.d/uenv.sh': Permission denied
# sed: can't read /etc/profile.d/uenv.sh: No such file or directory
# sed: can't read /etc/profile.d/uenv.sh: No such file or directory
# sed: can't read /etc/profile.d/uenv.sh: No such file or directory
# chmod: cannot access '/etc/profile.d/uenv.sh': No such file or directory
```

Using the `--local` option in the CI circumvent this limitation.