### PR TITLE
minor: allow missing environment description

### DIFF
--- a/uenv-impl
+++ b/uenv-impl
@@ -695,7 +695,7 @@ def generate_status_command(args, env):
             lines.append(f"  anonymous environment with no meta data")
         else:
             name = uenv.name
-            description = uenv.description
+            description = uenv.description or ""
             lines.append(f"{colorize(uenv.mount, 'cyan')}:{colorize(uenv.name, 'yellow')}")
             if len(description.strip()) == 0:
                 lines.append(f"  no description")


### PR DESCRIPTION
The environment [schema](https://github.com/eth-cscs/stackinator/blob/01fca056329bd2a42a7cd92e7cd334d09e7bba9a/stackinator/schema/config.json#L53-L59) allows not specifying description (actually it is the default).

Without this PR, such condition would lead to an exception (i.e. calling `None.strip()`).