### PR TITLE
fix unbound variable

### DIFF
--- a/install
+++ b/install
@@ -68,6 +68,9 @@ local_install=no
 # dry-run (systemwide install only)
 uenv_debug=no
 
+# default installation destination, only required for bulding rpm packages
+destdir=""
+
 # loop over all arguments
 for (( i=1; i<=arg_count; i++ ))
 do


### PR DESCRIPTION
`--destdir` flag is used to install the files into a working directory, for example used by package managers when creating binary packages.

Currently it was unbound when running `./install` as root. 