### PR TITLE
replace `uenv image create` with `uenv image repo` in error message

### DIFF
--- a/uenv-impl
+++ b/uenv-impl
@@ -636,9 +636,11 @@ def parse_image_descriptions(mnt_list, repo, uarch):
             try:
                 fscache = datastore.FileSystemRepo(repo_path)
             except datastore.RepoNotFoundError as err:
-                terminal.error(f"""The local repository {repo_path} does not exist.
-The repo can be created using the following command:
-  {colorize(f"uenv image -r {repo_path} create", "white")}
+                terminal.error(f"""The local repository {path} does not exist.
+If this is your first time using uenv, a repo in the default location can be created with this command:
+  {colorize(f"uenv image repo", "white")}
+If you want to create a repo in a custom location, provide the path as follows:
+  {colorize(f"uenv image repo {repo_path}", "white")}
 """, abort=False)
                 return []
             except datastore.RepoDBError as err:


### PR DESCRIPTION
Calls to `uenv start` that fail because no uenv repository exists print an error message that suggests the user create a new repository with `uenv image create`, which was replaced with `uenv image repo`.

Fix the error message to be the same as the one for calls to `uenv image *`.