### PR TITLE
Fix uenv help for wrong argument

### DIFF
--- a/uenv-impl
+++ b/uenv-impl
@@ -202,6 +202,11 @@ the available views will be printed.
             default=None,
             help="the view to load")
 
+    #### image
+    # Dummy sub-parser to print out the correct help when wrong keyword is used
+    # This is never used since "uenv image" commands are forwarded to "uenv-image"
+    _ = subparsers.add_parser("image", help="Manage and query uenv images.")
+
     return parser
 
 ###############################################################################
@@ -984,6 +989,13 @@ def generate_stop_command(args, env):
 if __name__ == "__main__":
     parser = make_argparser()
     args = parser.parse_args()
+
+    # Generate error if the dummy 'image' parser is called by accident
+    if args.command == "image":
+        raise RuntimeError(
+            "Something is wrong. 'image' sub-parser is a dummy parser. "
+            "'image' commands should be forwarded to 'uenv-image'."
+        )
 
     terminal.use_colored_output(args.no_color)
 


### PR DESCRIPTION
`uenv --help` prints the correct help via `uenv_usage`. However `uenv blabla` prints
```
$ uenv blabla
usage: uenv [-h] [--no-color] [--verbose] [-r REPO]
            {run,start,stop,status,modules,view} ...
uenv: error: argument command: invalid choice: 'blabla' (choose from 'run', 'start', 'stop', 'status', 'modules', 'view')
```
The `image` option is missing from the `uenv` help, since `uenv image` is not handled by `uenv-impl` but by `uenv-image`.

This PR adds a dummy parser so that the correct help is printed:
```
$ uenv blabla
usage: uenv [-h] [--no-color] [--verbose] [-r REPO]
            {run,start,stop,status,modules,view,image} ...
uenv: error: argument command: invalid choice: 'blabla' (choose from 'run', 'start', 'stop', 'status', 'modules', 'view', 'image')
```

A `RuntimeError` is raised should this command ever be called
```
$ python3 uenv-impl image
Traceback (most recent call last):
  File "uenv-impl", line 996, in <module>
    "Something is wrong. 'image' sub-parser is a dummy parser. "
RuntimeError: Something is wrong. 'image' sub-parser is a dummy parser. 'image' commands should be forwarded to 'uenv-image'.
```